### PR TITLE
Use different slugs for PF2e effects

### DIFF
--- a/scripts/utils/effects.js
+++ b/scripts/utils/effects.js
@@ -95,6 +95,12 @@ export class Effects {
         description: {
           value: game.i18n.localize('tokenlightcond-effect-dim-desc'),
         },
+        "rules": [
+          {
+            "key": "RollOption",
+            "option": "lighting:dim-light"
+          }
+        ],
         unidentified: true,
         traits: {
           custom: '',
@@ -131,6 +137,12 @@ export class Effects {
         description: {
           value: game.i18n.localize('tokenlightcond-effect-dark-desc'),
         },
+        "rules": [
+          {
+            "key": "RollOption",
+            "option": "lighting:darkness"
+          }
+        ],
         unidentified: true,
         traits: {
           custom: '',

--- a/scripts/utils/effects.js
+++ b/scripts/utils/effects.js
@@ -107,7 +107,7 @@ export class Effects {
         source: {
           value: '',
         },
-        slug: `tokenlightcondition-effect`,
+        slug: `tokenlightcondition-dim`,
       },
       flags: {}
     }
@@ -143,7 +143,7 @@ export class Effects {
         source: {
           value: '',
         },
-        slug: `tokenlightcondition-effect`,
+        slug: `tokenlightcondition-dark`,
       },
       flags: {}
     }


### PR DESCRIPTION
These slugs are used in the pf2e system to differentiate effects in the rules system.

With different slugs for both effects, the effects applied by this module can be used the interact with all the different rules in interesting ways.

The added roll options apply the appropriate lighting options to any rolls made by the actor. This allows for some items and abilities in the PF2e system to work out of the box.